### PR TITLE
feat: populate contacts from message senders automatically

### DIFF
--- a/src/app/sync.rs
+++ b/src/app/sync.rs
@@ -190,6 +190,34 @@ struct FetchedMessage {
     media_path: Option<String>,
     reply_to_id: Option<i64>,
     topic_id: Option<i32>,
+    /// Sender identity captured with the message, so `contacts` can be
+    /// populated at store time without any extra API call. `None` when the
+    /// sender is not a user (e.g. a channel) or is unknown.
+    sender_contact: Option<SenderContact>,
+}
+
+/// A message sender's identity, lifted from the `Peer` that already rides
+/// along with every fetched message. Used to upsert `contacts` for free.
+struct SenderContact {
+    user_id: i64,
+    username: Option<String>,
+    first_name: String,
+    last_name: String,
+    phone: String,
+}
+
+/// Extract a [`SenderContact`] from a message's sender peer, if it is a user.
+fn sender_contact_from_peer(sender: Option<&Peer>) -> Option<SenderContact> {
+    match sender {
+        Some(Peer::User(u)) => Some(SenderContact {
+            user_id: u.bare_id(),
+            username: u.username().map(|s| s.to_string()),
+            first_name: u.first_name().unwrap_or("").to_string(),
+            last_name: u.last_name().unwrap_or("").to_string(),
+            phone: u.phone().unwrap_or("").to_string(),
+        }),
+        _ => None,
+    }
 }
 
 /// Output representation of a synced message (used for Text/Json/Stream modes)
@@ -867,7 +895,10 @@ impl App {
                                     latest_ts = Some(msg_ts);
                                 }
 
-                                let sender_id = msg.sender().map(|s| s.id().bare_id()).unwrap_or(0);
+                                let sender = msg.sender();
+                                let sender_id =
+                                    sender.as_ref().map(|s| s.id().bare_id()).unwrap_or(0);
+                                let sender_contact = sender_contact_from_peer(sender);
                                 let from_me = msg.outgoing();
                                 let text = msg.text().to_string();
                                 let reply_to_id = msg.reply_to_message_id().map(|id| id as i64);
@@ -904,6 +935,7 @@ impl App {
                                     media_path,
                                     reply_to_id,
                                     topic_id,
+                                    sender_contact,
                                 };
 
                                 // Stream output immediately (before collecting all results)
@@ -1024,6 +1056,21 @@ impl App {
                         topic_id: msg.topic_id,
                     })
                     .await?;
+                // Populate contacts from the sender captured with the message
+                // (no extra API call — it rode along with the message history).
+                if let Some(c) = &msg.sender_contact {
+                    let _ = self
+                        .get_store()
+                        .await?
+                        .upsert_contact(
+                            c.user_id,
+                            c.username.as_deref(),
+                            &c.first_name,
+                            &c.last_name,
+                            &c.phone,
+                        )
+                        .await;
+                }
                 messages_stored += 1;
             }
 
@@ -1322,7 +1369,8 @@ impl App {
                     latest_ts = Some(msg_ts);
                 }
 
-                let sender_id = msg.sender().map(|s| s.id().bare_id()).unwrap_or(0);
+                let sender = msg.sender();
+                let sender_id = sender.as_ref().map(|s| s.id().bare_id()).unwrap_or(0);
                 let from_me = msg.outgoing();
 
                 let text = msg.text().to_string();
@@ -1364,6 +1412,20 @@ impl App {
                         topic_id,
                     })
                     .await?;
+                // Populate contacts from the message sender (free — no API call).
+                if let Some(c) = sender_contact_from_peer(sender) {
+                    let _ = self
+                        .get_store()
+                        .await?
+                        .upsert_contact(
+                            c.user_id,
+                            c.username.as_deref(),
+                            &c.first_name,
+                            &c.last_name,
+                            &c.phone,
+                        )
+                        .await;
+                }
                 messages_stored += 1;
 
                 // Show progress periodically
@@ -1648,7 +1710,8 @@ impl App {
                         latest_ts = Some(msg_ts);
                     }
 
-                    let sender_id = msg.sender().map(|s| s.id().bare_id()).unwrap_or(0);
+                    let sender = msg.sender();
+                    let sender_id = sender.as_ref().map(|s| s.id().bare_id()).unwrap_or(0);
                     let from_me = msg.outgoing();
 
                     let text = msg.text().to_string();
@@ -1687,6 +1750,20 @@ impl App {
                             topic_id,
                         })
                         .await?;
+                    // Populate contacts from the message sender (free — no API call).
+                    if let Some(c) = sender_contact_from_peer(sender) {
+                        let _ = self
+                            .get_store()
+                            .await?
+                            .upsert_contact(
+                                c.user_id,
+                                c.username.as_deref(),
+                                &c.first_name,
+                                &c.last_name,
+                                &c.phone,
+                            )
+                            .await;
+                    }
                     messages_stored += 1;
 
                     // Show progress periodically

--- a/src/cmd/chats.rs
+++ b/src/cmd/chats.rs
@@ -413,6 +413,19 @@ pub async fn run(cli: &Cli, cmd: &ChatsCommand) -> Result<()> {
                     role: format_role(&participant.role),
                 };
                 members.push(member);
+                // Persist each participant into contacts so message senders in
+                // this chat resolve to names (covers silent members too).
+                let _ = app
+                    .get_store()
+                    .await?
+                    .upsert_contact(
+                        user.bare_id(),
+                        user.username(),
+                        user.first_name().unwrap_or(""),
+                        user.last_name().unwrap_or(""),
+                        user.phone().unwrap_or(""),
+                    )
+                    .await;
                 count += 1;
 
                 // Check limit (0 = unlimited)

--- a/src/cmd/daemon.rs
+++ b/src/cmd/daemon.rs
@@ -334,6 +334,26 @@ pub async fn run(cli: &Cli, args: &DaemonArgs) -> Result<()> {
                                     messages_stored.fetch_add(1, Ordering::Relaxed);
                                 }
 
+                                // Populate contacts from the sender in real time so
+                                // names resolve. Costs nothing — the sender object
+                                // already arrived with the update.
+                                if let Some(Peer::User(user)) = msg.sender() {
+                                    if let Err(e) = app
+                                        .get_store()
+                                        .await?
+                                        .upsert_contact(
+                                            user.bare_id(),
+                                            user.username(),
+                                            user.first_name().unwrap_or(""),
+                                            user.last_name().unwrap_or(""),
+                                            user.phone().unwrap_or(""),
+                                        )
+                                        .await
+                                    {
+                                        log::warn!("Failed to upsert sender contact: {}", e);
+                                    }
+                                }
+
                                 // Update chat metadata
                                 let chat_name = chat_name_from_peer(&peer);
                                 let username = username_from_peer(&peer);


### PR DESCRIPTION
## Problem

`contacts` is only populated from the address book (dialog peers and `contacts.*` lookups). The sender of a message from someone **not** in your address book — common in groups/supergroups — has no stored name, so message output and SQL analytics fall back to `user:<id>`. The name can't be recovered later from a bare numeric id, because resolving a user requires its `access_hash`.

## Change

Every fetched message and every real-time update already carries its sender as a `Peer`, but only the bare id was retained. This upserts the sender into `contacts` at each point a message is processed — **no extra API calls, no schema change, no new dependencies**:

- **daemon** (`src/cmd/daemon.rs`): each incoming `NewMessage` upserts its sender → contacts stay current in real time.
- **sync** (`src/app/sync.rs`): the three message paths (`sync`, `sync_msgs`, deep `fetch`) upsert the senders of messages they pull. Adds a `SenderContact` field on `FetchedMessage` and a small `sender_contact_from_peer` helper.
- **`chats members`** (`src/cmd/chats.rs`): persists every participant it lists (also covers members who haven't posted).

All four reuse the existing idempotent `Store::upsert_contact`, whose `ON CONFLICT … DO UPDATE` uses `COALESCE`/non-empty guards, so a good value is never overwritten with an empty one. Failures are best-effort (logged in the daemon, ignored elsewhere) so contact population never breaks message storage.

## Testing

- `cargo build --release` — clean.
- Ran the daemon, `sync` / `sync msgs`, and `chats members` against a live account: group senders that previously showed as `user:<id>` now resolve to names in `contacts`; re-runs are idempotent and don't clobber existing names.
